### PR TITLE
Spec test fixes

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,8 @@ fixtures:
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '4.5.1'
+    stdlibplus:
+      repo: 'git://github.com/juliengk/puppet-stdlibplus.git'
+      ref: 'v0.1.8'
   symlinks:
     env: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ env:
     - PUPPET_GEM_VERSION="~> 3.6.0"
     - PUPPET_GEM_VERSION="~> 3.7.0"
     - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4"
+    - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 language: 'ruby'
 rvm:
@@ -41,3 +49,17 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.3.0"
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ rvm:
   - 2.0.0
   - 2.1.0
 
-gemfile: 'Gemfile'
-
 before_script: 'gem install --no-ri --no-rdoc bundler'
 script:
   - 'bundle exec rake validate'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,23 @@ notifications:
   email: false
 
 env:
-  - PUPPET_VERSION=3.3.2
-  - PUPPET_VERSION=3.4.2
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.1"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
 
 language: 'ruby'
 rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.0
+
 gemfile: 'Gemfile'
 
 before_script: 'gem install --no-ri --no-rdoc bundler'
@@ -18,3 +27,17 @@ script:
   - 'bundle exec rake validate'
   - 'bundle exec rake lint'
   - 'SPEC_OPTS="--format documentation" bundle exec rake spec'
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet', '~>1.0'
+gem 'rspec-puppet'
 
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,11 @@ end
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
-gem 'rspec', '~>2.0'
 gem 'rspec-puppet', '~>1.0'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+  # rake >= 11 does not support ruby 1.8.7
+  gem 'rake', '~> 10.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-if puppetversion = ENV['PUPPET_VERSION']
+if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion, :require => false
 else
     gem 'puppet', :require => false

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -145,7 +145,7 @@ describe 'env', :type => 'class' do
       it do
         expect {
           should contain_class('env')
-        }.to raise_error(Puppet::Error, /env::content_sh must be a string./)
+        }.to raise_error(Puppet::Error, /is not a string.\s+It looks to be a Array./)
       end
     end
   end
@@ -186,7 +186,7 @@ describe 'env', :type => 'class' do
       it do
         expect {
           should contain_class('env')
-        }.to raise_error(Puppet::Error, /env::content_csh must be a string./)
+        }.to raise_error(Puppet::Error, /is not a string.\s+It looks to be a Array./)
       end
     end
   end

--- a/spec/classes/path_spec.rb
+++ b/spec/classes/path_spec.rb
@@ -34,7 +34,7 @@ describe 'env::path', :type => 'class' do
     it do
       expect {
         should contain_class('env::path')
-      }.to raise_error(Puppet::Error, /^env::path supports OS families RedHat, Suse, Debian and Solaris. Detected osfamily is <CoreOS>./)
+      }.to raise_error(Puppet::Error, /env::path supports OS families RedHat, Suse, Debian and Solaris. Detected osfamily is <CoreOS>./)
     end
   end
 
@@ -46,7 +46,7 @@ describe 'env::path', :type => 'class' do
         it do
           expect {
             should contain_class('env::path')
-          }.to raise_error(Puppet::Error, /^env::path::directories is MANDATORY./)
+          }.to raise_error(Puppet::Error, /env::path::directories is MANDATORY./)
         end
       end
     end
@@ -99,7 +99,7 @@ describe 'env::path', :type => 'class' do
       it do
         expect {
           should contain_class('env')
-        }.to raise_error(Puppet::Error, /^env::path::profile_file_ensure is <directory>. Must be present or absent./)
+        }.to raise_error(Puppet::Error, /env::path::profile_file_ensure is <directory>. Must be present or absent./)
       end
     end
   end
@@ -173,7 +173,7 @@ describe 'env::path', :type => 'class' do
         it do
           expect {
             should contain_class('env::path')
-          }.to raise_error(Puppet::Error, /^^str2bool\(\): Unknown type of boolean/)
+          }.to raise_error(Puppet::Error, /str2bool\(\): Unknown type of boolean/)
         end
       end
     end
@@ -185,7 +185,7 @@ describe 'env::path', :type => 'class' do
       it do
         expect {
           should contain_class('env::path')
-        }.to raise_error(Puppet::Error, /^env::path::directories must be an array./)
+        }.to raise_error(Puppet::Error, /env::path::directories must be an array./)
       end
     end
   end
@@ -203,7 +203,7 @@ describe 'env::path', :type => 'class' do
       it do
         expect {
           should contain_class('env::path')
-        }.to raise_error(Puppet::Error, /^env::path::enable_hiera_array must be of type boolean or string./)
+        }.to raise_error(Puppet::Error, /env::path::enable_hiera_array must be of type boolean or string./)
       end
     end
   end
@@ -233,7 +233,7 @@ describe 'env::path', :type => 'class' do
       it do
         expect {
           should contain_class('env::path')
-        }.to raise_error(Puppet::Error, /^env::path::include_existing_path must be of type boolean or string./)
+        }.to raise_error(Puppet::Error, /env::path::include_existing_path must be of type boolean or string./)
       end
     end
 
@@ -249,7 +249,7 @@ describe 'env::path', :type => 'class' do
       it do
         expect {
           should contain_class('env::path')
-        }.to raise_error(Puppet::Error, /^str2bool\(\): Unknown type of boolean/)
+        }.to raise_error(Puppet::Error, /str2bool\(\): Unknown type of boolean/)
       end
     end
   end
@@ -326,7 +326,7 @@ describe 'env::path', :type => 'class' do
       it do
         expect {
           should contain_class('env::path')
-        }.to raise_error(Puppet::Error, /^env::path::profile_file must be a string and match the regex./)
+        }.to raise_error(Puppet::Error, /env::path::profile_file must be a string and match the regex./)
       end
     end
   end

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -185,7 +185,7 @@ describe 'env::proxy', :type => 'class' do
       it do
         expect {
           should contain_class('env::proxy')
-        }.to raise_error(Puppet::Error, /^env::proxy::url is <proxy.example.com10>\. Must be an url\./)
+        }.to raise_error(Puppet::Error, /validate_fqdn\(\): "#{params[:url]}" is not a valid FQDN./)
       end
     end
   end
@@ -285,7 +285,7 @@ describe 'env::proxy', :type => 'class' do
         it do
           expect {
             should contain_class('env::proxy')
-          }.to raise_error(Puppet::Error, /env::proxy::url is <#{url}>. Must be an url./)
+          }.to raise_error(Puppet::Error, /validate_fqdn\(\): "#{params[:url]}" is not a valid FQDN./)
         end
       end
     end
@@ -320,12 +320,12 @@ describe 'env::proxy', :type => 'class' do
         it do
           expect {
             should contain_class('env::proxy')
-          }.to raise_error(Puppet::Error, /^env::proxy::port is <#{port}>. Must match the regex./)
+          }.to raise_error(Puppet::Error, /validate_port\(\): #{port} is not a valid port number./)
         end
       end
     end
 
-    [ true, 80.0 ].each do |port|
+    [ true, 80.2 ].each do |port|
       context "to an invalid value <#{port}>" do
         let(:facts) { { :osfamily => 'RedHat' } }
         let(:params) do
@@ -338,7 +338,7 @@ describe 'env::proxy', :type => 'class' do
         it do
           expect {
             should contain_class('env::proxy')
-          }.to raise_error(Puppet::Error, /^env::proxy::port is <#{port}>. Must be an integer or a string./)
+          }.to raise_error(Puppet::Error, /validate_port\(\): #{port} is not a valid port number./)
         end
       end
     end

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -34,7 +34,7 @@ describe 'env::proxy', :type => 'class' do
     it do
       expect {
         should contain_class('env::proxy')
-      }.to raise_error(Puppet::Error, /^env::proxy supports OS families RedHat, Suse, Debian and Solaris. Detected osfamily is <CoreOS>./)
+      }.to raise_error(Puppet::Error, /env::proxy supports OS families RedHat, Suse, Debian and Solaris. Detected osfamily is <CoreOS>./)
     end
   end
 
@@ -46,7 +46,7 @@ describe 'env::proxy', :type => 'class' do
         it do
           expect {
             should contain_class('env::proxy')
-          }.to raise_error(Puppet::Error, /^env::proxy::url is MANDATORY./)
+          }.to raise_error(Puppet::Error, /env::proxy::url is MANDATORY./)
         end
       end
     end
@@ -99,7 +99,7 @@ describe 'env::proxy', :type => 'class' do
       it do
         expect {
           should contain_class('env::proxy')
-        }.to raise_error(Puppet::Error, /^env::proxy::profile_file_ensure is <directory>. Must be present or absent./)
+        }.to raise_error(Puppet::Error, /env::proxy::profile_file_ensure is <directory>. Must be present or absent./)
       end
     end
   end
@@ -173,7 +173,7 @@ describe 'env::proxy', :type => 'class' do
         it do
           expect {
             should contain_class('env::proxy')
-          }.to raise_error(Puppet::Error, /^^str2bool\(\): Unknown type of boolean/)
+          }.to raise_error(Puppet::Error, /str2bool\(\): Unknown type of boolean/)
         end
       end
     end
@@ -233,7 +233,7 @@ describe 'env::proxy', :type => 'class' do
       it do
         expect {
           should contain_class('env::proxy')
-        }.to raise_error(Puppet::Error, /^env::proxy::profile_file must be a string and match the regex./)
+        }.to raise_error(Puppet::Error, /env::proxy::profile_file must be a string and match the regex./)
       end
     end
   end
@@ -263,7 +263,7 @@ describe 'env::proxy', :type => 'class' do
       it do
         expect {
           should contain_class('env::path')
-        }.to raise_error(Puppet::Error, /^env::proxy::enable_hiera_array must be of type boolean or string./)
+        }.to raise_error(Puppet::Error, /env::proxy::enable_hiera_array must be of type boolean or string./)
       end
     end
   end
@@ -338,7 +338,7 @@ describe 'env::proxy', :type => 'class' do
         it do
           expect {
             should contain_class('env::proxy')
-          }.to raise_error(Puppet::Error, /validate_port\(\): #{port} is not a valid port number./)
+          }.to raise_error(Puppet::Error, /validate_port\(\): .?#{port}.? is not a valid port number./)
         end
       end
     end
@@ -373,7 +373,7 @@ describe 'env::proxy', :type => 'class' do
       it do
         expect {
           should contain_class('env::proxy')
-        }.to raise_error(Puppet::Error, /^env::proxy::exceptions must be an array./)
+        }.to raise_error(Puppet::Error, /env::proxy::exceptions must be an array./)
       end
     end
   end


### PR DESCRIPTION
Hi,

I've fixed the spec tests for Puppet v3 and Puppet v4. I've also added all missing versions of Puppetv3.

There's still one spec test failing. It's failing because the fact always converts everything to integers which converts 80.2 (used in spec test) to 80 instead.

I'm not sure if this check should be removed or if you want to update the fact not to convert it to an integer.
