### PR TITLE
Support Puppet 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5"
+  - rvm: 2.5.1
+    env: PUPPET_GEM_VERSION="~> 6"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,25 +19,17 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
-  - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
-  - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
-  - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 3"
   - rvm: 2.1.9


### PR DESCRIPTION
Hej @juliengk,

it got decided to start upgrading our modules to support Puppet 6 already.
To get this 'new version' into production it would be good if you could create a new release tag after you merged this.

Thanks
Phil